### PR TITLE
Fix encoding errors while downloading web pages

### DIFF
--- a/lib/schiphol.rb
+++ b/lib/schiphol.rb
@@ -99,6 +99,8 @@ class Schiphol
       
           # Write the downloaded file.
           response.read_body do |segment|
+            segment.force_encoding('UTF-8')
+
             # Increment the progress bar.
             bar.inc(segment.length) if bar
             # Write the read segment.


### PR DESCRIPTION
Sample Error

rake aborted!:  32% |ooooooooooooooo                                |
ETA:   0:00:00
Couldn't download
http://www.theverge.com/2012/10/24/3551336/kindle-ios-update-x-ray-japanese
(Max number of attempts reached). Error: ("\xE2" from ASCII-8BIT to
UTF-8)
