### PR TITLE
use v 0.9.9 of rubyzip, fixes #5

### DIFF
--- a/schiphol.gemspec
+++ b/schiphol.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*'] + ['README.md', 'LICENSE']
   
   # Runtime dependencies
-  s.add_runtime_dependency 'rubyzip', '>= 0.9.6.1'
+  s.add_runtime_dependency 'rubyzip', '~> 0.9.9'
   s.add_runtime_dependency 'progressbar', '>= 0.10.0'
   
 end


### PR DESCRIPTION
Tracked this issue from https://github.com/louismullie/treat/issues/64 , it'd help the flow of installing treat not to have to install zip separately.
