### PR TITLE
Fixing dependency that breaks others gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source :rubygems
 
+#There are serious changes in 1.0, this is required to fix Schiphol's uage in rubygem: treat which uses schiphol
+gem 'rubyzip', '< 1.0.0’
+
+
 gemspec


### PR DESCRIPTION
There are serious changes in 1.0, this is required to fix Schiphol's uage in rubygem: treat which uses schiphol.
thanks
